### PR TITLE
Improve findJiras() response handling

### DIFF
--- a/SupportCasesSync.js
+++ b/SupportCasesSync.js
@@ -175,8 +175,15 @@ function findJiras(communicationsArr, displayId, callback) {
             return;
         }
 
+        // Evaluate response status code before parsing response body
+        // (Jira returns HTML for HTTP 401, regardless of request Content-Type, upon which JSON.parse() fails)
+        if (response.statusCode != 200) {
+            console.log(`Unable to find Jira IDs: Jira responded with HTTP ${response.statusCode}.`);
+            return;
+        }
+
         let jsonResponse = JSON.parse(body);
-        if (response.statusCode == 200 && jsonResponse.total != 0) {
+        if (jsonResponse.total != 0) {
             jsonResponse.issues.forEach(function (issue) {
                 //verifying if this was second custom field reference (needed later for colorizing)
                 callback(communicationsArr, issue, (issue.fields[config.jiraAwsFieldName2.id] == displayId));


### PR DESCRIPTION
This PR adds response status code evaluation before parsing the response body in `findJiras()`.

Jira (Cloud) returns HTML when throwing HTTP 401, regardless of the request's Content-Type. `JSON.parse()` fails at parsing that HTML:

```
SyntaxError: Unexpected token < in JSON at position 10
at Object.parse (native)
at Request._callback (/var/task/SupportCasesSync.js:179:33)
at Request.self.callback (/var/task/node_modules/request/request.js:186:22)
at emitTwo (events.js:106:13)
at Request.emit (events.js:191:7)
at Request.<anonymous> (/var/task/node_modules/request/request.js:1163:10)
at emitOne (events.js:96:13)
at Request.emit (events.js:188:7)
at IncomingMessage.<anonymous> (/var/task/node_modules/
```

This change potentially helps when debugging, in the case of faulty authentication keys/credentials. (Or when other, non-expected HTTP status codes are thrown.)

By all means edit as you see fit.

cc @williamhughes123